### PR TITLE
feat: fetch fees from esplora

### DIFF
--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -20,7 +20,7 @@ pub(crate) use create::Create;
 pub(crate) use footer::Footer;
 pub(crate) use home::Home;
 pub(crate) use input::{
-    AddressInput, BitcoinInput, EscrowTypeInput, EsploraInput, FeeRateInput, NetworkInput,
+    AddressInput, BitcoinInput, EscrowTypeInput, EsploraInput, FeeRateSelector, NetworkInput,
     NpubInput, NpubInputDerivedAddress, NsecInput, SignatureInput, TimelockInput, TransactionInput,
     TxidInput, VoutInput,
 };

--- a/src/esplora.rs
+++ b/src/esplora.rs
@@ -1,5 +1,5 @@
 //! Interactions with Esplora backends.
-#![allow(dead_code)] // TODO: Dynamic fee estimates
+#![allow(dead_code)]
 
 use std::collections::HashMap;
 


### PR DESCRIPTION
Closes #33.

This PR removes `FeeRateInput` and creates `FeeRateSelector`, which adds a dropdown beside the input field with target blocks and their corresponding fee rates fetched from the esplora endpoint.