### PR TITLE
chore(deps): bump `bitcoin` to 0.32.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ license = "MIT"
 
 [dependencies]
 # NOTE: keep bitcoin and secp256k1 versions in sync.
-bitcoin = { version = "0.32.5", default-features = false, features = [
+bitcoin = { version = "0.32.6", default-features = false, features = [
     "std",
     "serde",
     "secp-recovery",

--- a/src/sign.rs
+++ b/src/sign.rs
@@ -37,7 +37,7 @@ pub(crate) fn sign_resolution_tx(
 
     // For key path spend, we need to apply taproot tweak.
     let tweaked = keypair.tap_tweak(SECP256K1, None);
-    let signature = SECP256K1.sign_schnorr_no_aux_rand(&message, &tweaked.to_inner());
+    let signature = SECP256K1.sign_schnorr_no_aux_rand(&message, &tweaked.to_keypair());
     #[cfg(debug_assertions)]
     trace!(signature = %signature, txid = %transaction.compute_txid(), "Signature resolution transaction");
     let mut transaction = transaction.clone();


### PR DESCRIPTION
## Changelog
- Bump `bitcoin` to 0.32.6.
- Swap `to_inner()` to `to_keypair()`.